### PR TITLE
add note about activating AWS SES

### DIFF
--- a/documentation/reference/nucleatorquickstart.txt
+++ b/documentation/reference/nucleatorquickstart.txt
@@ -94,6 +94,7 @@ c. If you are visiting the console using your AWS Console shortcut link for
    root account credentials" beneath the Sign In button to get to the "Sign In
    or Create an AWS Account" Page
 d. Complete the Account Signup process using the conventions described below
+e. Be sure to activate SES - it requires some extra steps after AWS account signup
 +
 *Account Name:* `<youraccountname>-<yourcustomername>`
 +


### PR DESCRIPTION
When following the [quickstart guide](https://47lining.github.io/nucleator/documentation/nucleatorquickstart.html) I was not able to complete the setup of all the roles with error: `The AWS Access Key Id needs a subscription for the service`

I was able to track this down to the fact that a new AWS account does not have SES activated.  
Once I ativated SES the playbook completed as expected.
